### PR TITLE
Improve smb download error handling

### DIFF
--- a/smbmap.py
+++ b/smbmap.py
@@ -1023,21 +1023,22 @@ class SMBMap():
         filename = path.split('\\')[-1]
         share = path.split('\\')[0]
         path = path.replace(share, '')
+        output_path = ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_'))))
         try:
-            out = open(ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_')))),'wb')
+            out = open(output_path,'wb')
             dlFile = self.smbconn[host].listPath(share, path)
 
             msg = '[+] Starting download: %s (%s bytes)' % ('%s%s' % (share, path), dlFile[0].get_filesize())
             if self.pattern:
                 msg = '\t' + msg
-                logger.info(msg)
+                logger.debug(msg)
 
             self.smbconn[host].getFile(share, path, out.write)
             
             msg = '[+] File output to: %s/%s' % (os.getcwd(), ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_')))))
             if self.pattern:
                 msg = '\t'+msg
-                logger.info(msg)
+                logger.debug(msg)
         except SessionError as e:
             error_message = str(e)
             if 'STATUS_ACCESS_DENIED' in error_message:
@@ -1054,9 +1055,10 @@ class SMBMap():
                 logger.error(str(e))
         except Exception as e:
             logger.error('[!] Error retrieving file, unknown error')
-            os.remove(filename)
             out.close()
-        return '%s/%s' % (os.getcwd(), ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_')))))
+            os.remove(output_path)
+        out.close()
+        return '%s/%s' % (os.getcwd(), output_path)
 
     def exec_command(self, host, share, command, disp_output=True, host_name=None, mode='wmi'):
         try:

--- a/smbmap.py
+++ b/smbmap.py
@@ -1022,18 +1022,18 @@ class SMBMap():
         path = ntpath.normpath(path)
         filename = path.split('\\')[-1]
         share = path.split('\\')[0]
-        path = path.replace(share, '')
+        path = path.replace(share, '', 1)
         output_path = ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_'))))
         try:
-            out = open(output_path,'wb')
             dlFile = self.smbconn[host].listPath(share, path)
 
             msg = '[+] Starting download: %s (%s bytes)' % ('%s%s' % (share, path), dlFile[0].get_filesize())
             if self.pattern:
                 msg = '\t' + msg
-                logger.debug(msg)
+            logger.debug(msg)
 
-            self.smbconn[host].getFile(share, path, out.write)
+            with open(output_path,'wb') as out:
+                self.smbconn[host].getFile(share, path, out.write)
             
             msg = '[+] File output to: %s/%s' % (os.getcwd(), ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_')))))
             if self.pattern:
@@ -1047,7 +1047,6 @@ class SMBMap():
                 logger.error('[!] Error retrieving file, invalid path')
             elif 'STATUS_SHARING_VIOLATION' in error_message:
                 logger.error('[!] Error retrieving file %s, sharing violation' % (filename))
-                os.remove(output_path)
             elif 'STATUS_NO_SUCH_FILE' in error_message:
                 logger.error('[!] Error retrieving file %s, file not found on network share' % filename)
             else:
@@ -1055,9 +1054,6 @@ class SMBMap():
                 logger.error(str(e))
         except Exception as e:
             logger.error('[!] Error retrieving file, unknown error')
-            out.close()
-            os.remove(output_path)
-        out.close()
         return '%s/%s' % (os.getcwd(), output_path)
 
     def exec_command(self, host, share, command, disp_output=True, host_name=None, mode='wmi'):

--- a/smbmap.py
+++ b/smbmap.py
@@ -1038,7 +1038,7 @@ class SMBMap():
             msg = '[+] File output to: %s/%s' % (os.getcwd(), ntpath.basename('%s/%s' % (os.getcwd(), '%s-%s%s' % (host, share.replace('$',''), path.replace('\\','_')))))
             if self.pattern:
                 msg = '\t'+msg
-                logger.debug(msg)
+            logger.debug(msg)
         except SessionError as e:
             error_message = str(e)
             if 'STATUS_ACCESS_DENIED' in error_message:


### PR DESCRIPTION
Original Scenario: Attempting to download a file named backup_credentials.txt from SMB share named backup

The path manipulations in the download_file function will replace any instance of the share name with empty space
`path = path.replace(share, '')`

In our scenario, the path variable will evaluate to `\\_credentials.txt` rather than the expected `\\backup_credentials.txt`

A quick fix is to limit the replace to only one occurance
`path = path.replace(share, '', 1)`

While debugging this issue, I noticed the handle for the output file path was not always closed if exceptions were raised. A good way to correct this issue is by creating the file handle using a `with` statement so the handle will definitely be closed.